### PR TITLE
Use project notation when deploying CorDapps to nodes.

### DIFF
--- a/cordapp-example/workflows-java/build.gradle
+++ b/cordapp-example/workflows-java/build.gradle
@@ -70,7 +70,7 @@ tasks.withType(JavaCompile) {
 task deployNodes(type: Cordform, dependsOn: ['jar']) {
     directory "./build/nodes"
     nodeDefaults {
-        cordapp("$project.group:contracts-java:$project.version")
+        cordapp project(":contracts-java")
     }
     node {
         name "O=Notary,L=London,C=GB"

--- a/cordapp-example/workflows-kotlin/build.gradle
+++ b/cordapp-example/workflows-kotlin/build.gradle
@@ -78,7 +78,7 @@ tasks.withType(KotlinCompile) {
 task deployNodes(type: Cordform, dependsOn: ['jar']) {
     directory "./build/nodes"
     nodeDefaults {
-        cordapp("$project.group:contracts-kotlin:$project.version")
+        cordapp project(":contracts-kotlin")
     }
     node {
         name "O=Notary,L=London,C=GB"


### PR DESCRIPTION
The CorDapps we are deploying are internal Gradle modules and so use the `project('...')` notation.