### PR TITLE
CORDA-2612: Ensure that tests create their log files inside the build directory.

### DIFF
--- a/cordapp-example/config/test/log4j2-test.xml
+++ b/cordapp-example/config/test/log4j2-test.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="info">
+    <Properties>
+        <Property name="log-path">build/logs</Property>
+        <Property name="log-name">node-${hostName}</Property>
+    </Properties>
+
     <Appenders>
         <Console name="Console-Appender" target="SYSTEM_OUT">
             <PatternLayout>
@@ -8,13 +13,19 @@
                 </pattern>>
             </PatternLayout>
         </Console>
+        <File name="File-Appender"
+              fileName="${log-path}/${log-name}.log" immediateFlush="false" append="true">
+            <PatternLayout pattern="[%-5level] %d{ISO8601}{GMT+0} [%t] %c{1} - %msg%n"/>
+        </File>
     </Appenders>
     <Loggers>
         <Root level="info">
             <AppenderRef ref="Console-Appender"/>
+            <AppenderRef ref="File-Appender"/>
         </Root>
         <Logger name="net.corda" level="info" additivity="false">
             <AppenderRef ref="Console-Appender"/>
+            <AppenderRef ref="File-Appender"/>
         </Logger>
     </Loggers>
 </Configuration>

--- a/cordapp-example/workflows-java/build.gradle
+++ b/cordapp-example/workflows-java/build.gradle
@@ -68,7 +68,6 @@ tasks.withType(JavaCompile) {
 }
 
 task deployNodes(type: Cordform, dependsOn: ['jar']) {
-    directory "./build/nodes"
     nodeDefaults {
         cordapp project(":contracts-java")
     }

--- a/cordapp-example/workflows-kotlin/build.gradle
+++ b/cordapp-example/workflows-kotlin/build.gradle
@@ -76,7 +76,6 @@ tasks.withType(KotlinCompile) {
 }
 
 task deployNodes(type: Cordform, dependsOn: ['jar']) {
-    directory "./build/nodes"
     nodeDefaults {
         cordapp project(":contracts-kotlin")
     }


### PR DESCRIPTION
Log4J2 will use `log4j2-test.xml` in preference to a `log4j2.xml` file, so rename the test one and ensure it logs to a file inside the `build` directory. This will ensure that old log files can be cleaned between builds.

And `CordFormation` creates nodes inside `build/nodes` by default, so those lines don't need to be there either.