### PR TITLE
Update samples to make them better example CorDapps

### DIFF
--- a/blacklist/.idea/runConfigurations/Upload_blacklist.xml
+++ b/blacklist/.idea/runConfigurations/Upload_blacklist.xml
@@ -6,7 +6,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="MAIN_CLASS_NAME" value="net.corda.examples.attachments.client.ClientKt" />
+    <option name="MAIN_CLASS_NAME" value="net.corda.examples.attachments.tests.client.ClientKt" />
     <option name="WORKING_DIRECTORY" value="" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/blacklist/build.gradle
+++ b/blacklist/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'
@@ -102,7 +102,9 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address("localhost:10003")
             adminAddress("localhost:10043")
         }
-        cordapps = []
+        projectCordapp {
+            deploy = false
+        }
     }
     node {
         name "O=Monogram Bank,L=London,C=GB"
@@ -136,8 +138,8 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
 }
 
-task uploadBlacklist(type: JavaExec) {
-    classpath = sourceSets.main.runtimeClasspath
-    main = 'net.corda.examples.attachments.client.ClientKt'
+task uploadBlacklist(type: JavaExec, dependsOn: compileTestKotlin) {
+    classpath = sourceSets.test.runtimeClasspath
+    main = 'net.corda.examples.attachments.tests.client.ClientKt'
     args 'localhost:10007', 'localhost:10010', 'localhost:10013'
 }

--- a/blacklist/src/test/kotlin/net/corda/examples/attachments/tests/client/Client.kt
+++ b/blacklist/src/test/kotlin/net/corda/examples/attachments/tests/client/Client.kt
@@ -1,4 +1,4 @@
-package net.corda.examples.attachments.client
+package net.corda.examples.attachments.tests.client
 
 import net.corda.client.rpc.CordaRPCClient
 import net.corda.core.crypto.SecureHash

--- a/contract-upgrades/build.gradle
+++ b/contract-upgrades/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'

--- a/contract-upgrades/build.gradle
+++ b/contract-upgrades/build.gradle
@@ -121,7 +121,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     }
 }
 
-task runUpgradeContractClient(type: JavaExec) {
+task runUpgradeContractClient(type: JavaExec, dependsOn: assemble) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'com.upgrade.client.ClientKt'
     args = ['localhost:10006', 'localhost:10009']

--- a/contract-upgrades/build.gradle
+++ b/contract-upgrades/build.gradle
@@ -25,15 +25,33 @@ buildscript {
     }
 }
 
-repositories {
-    mavenLocal()
-    jcenter()
-    mavenCentral()
-    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
-    maven { url 'https://jitpack.io' }
+allprojects {
+    apply plugin: 'kotlin'
+
+    repositories {
+        mavenLocal()
+        jcenter()
+        mavenCentral()
+        maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
+        maven { url 'https://jitpack.io' }
+    }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
+        kotlinOptions {
+            languageVersion = "1.2"
+            apiVersion = "1.2"
+            jvmTarget = "1.8"
+            javaParameters = true   // Useful for reflection.
+        }
+    }
+
+    jar {
+        // This makes the JAR's SHA-256 hash repeatable.
+        preserveFileTimestamps = false
+        reproducibleFileOrder = true
+    }
 }
 
-apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.cordapp'
 apply plugin: 'net.corda.plugins.cordformation'
 
@@ -71,15 +89,6 @@ dependencies {
     cordapp project(":cordapp-contracts-states")
     cordapp project(":cordapp-new-contract")
     cordapp project(":cordapp-new-contract-with-legacy-constraint")
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
-    kotlinOptions {
-        languageVersion = "1.2"
-        apiVersion = "1.2"
-        jvmTarget = "1.8"
-        javaParameters = true   // Useful for reflection.
-    }
 }
 
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {

--- a/contract-upgrades/cordapp-contracts-states/build.gradle
+++ b/contract-upgrades/cordapp-contracts-states/build.gradle
@@ -38,3 +38,9 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
         javaParameters = true   // Useful for reflection.
     }
 }
+
+jar {
+    // This makes the JAR's SHA-256 hash repeatable.
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}

--- a/contract-upgrades/cordapp-contracts-states/build.gradle
+++ b/contract-upgrades/cordapp-contracts-states/build.gradle
@@ -28,9 +28,6 @@ dependencies {
 
     // Corda dependencies.
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-jackson:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-rpc:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-node-api:$corda_release_version"
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/contract-upgrades/cordapp-contracts-states/build.gradle
+++ b/contract-upgrades/cordapp-contracts-states/build.gradle
@@ -1,12 +1,3 @@
-repositories {
-    mavenLocal()
-    jcenter()
-    mavenCentral()
-    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
-    maven { url 'https://jitpack.io' }
-}
-
-apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.cordapp'
 
 cordapp {
@@ -28,19 +19,4 @@ dependencies {
 
     // Corda dependencies.
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
-    kotlinOptions {
-        languageVersion = "1.2"
-        apiVersion = "1.2"
-        jvmTarget = "1.8"
-        javaParameters = true   // Useful for reflection.
-    }
-}
-
-jar {
-    // This makes the JAR's SHA-256 hash repeatable.
-    preserveFileTimestamps = false
-    reproducibleFileOrder = true
 }

--- a/contract-upgrades/cordapp-new-contract-with-legacy-constraint/build.gradle
+++ b/contract-upgrades/cordapp-new-contract-with-legacy-constraint/build.gradle
@@ -1,12 +1,3 @@
-repositories {
-    mavenLocal()
-    jcenter()
-    mavenCentral()
-    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
-    maven { url 'https://jitpack.io' }
-}
-
-apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.cordapp'
 
 cordapp {
@@ -31,13 +22,4 @@ dependencies {
 
     // CorDapp dependencies.
     cordapp project(":cordapp-contracts-states")
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
-    kotlinOptions {
-        languageVersion = "1.2"
-        apiVersion = "1.2"
-        jvmTarget = "1.8"
-        javaParameters = true   // Useful for reflection.
-    }
 }

--- a/contract-upgrades/cordapp-new-contract-with-legacy-constraint/build.gradle
+++ b/contract-upgrades/cordapp-new-contract-with-legacy-constraint/build.gradle
@@ -28,9 +28,6 @@ dependencies {
 
     // Corda dependencies.
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-jackson:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-rpc:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-node-api:$corda_release_version"
 
     // CorDapp dependencies.
     cordapp project(":cordapp-contracts-states")

--- a/contract-upgrades/cordapp-new-contract-with-legacy-constraint/src/main/kotlin/com/upgrade/new/with/legacy/constraint/NewContractWithLegacyConstraint.kt
+++ b/contract-upgrades/cordapp-new-contract-with-legacy-constraint/src/main/kotlin/com/upgrade/new/with/legacy/constraint/NewContractWithLegacyConstraint.kt
@@ -10,7 +10,8 @@ import net.corda.core.transactions.LedgerTransaction
 // Upgraded contracts must implement the UpgradedContract interface.
 class NewContractWithLegacyConstraint : UpgradedContractWithLegacyConstraint<OldState, NewState> {
 
-    override val legacyContractConstraint = HashAttachmentConstraint(SecureHash.parse("95de7d5505cf2435d36b9321940d68756f6fe3f2ba2cc87121d477c4b8b968b2"))
+    // SHA-256 hash of the JAR containing the old contract.
+    override val legacyContractConstraint = HashAttachmentConstraint(SecureHash.parse("2b13ef694233556ad3cd86b0ef693bd40484c60a66599317df244c6245d64e6a"))
 
     companion object {
         const val id = "com.upgrade.new.with.legacy.constraint.NewContractWithLegacyConstraint"

--- a/contract-upgrades/cordapp-new-contract/build.gradle
+++ b/contract-upgrades/cordapp-new-contract/build.gradle
@@ -1,12 +1,3 @@
-repositories {
-    mavenLocal()
-    jcenter()
-    mavenCentral()
-    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
-    maven { url 'https://jitpack.io' }
-}
-
-apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.cordapp'
 
 cordapp {
@@ -31,13 +22,4 @@ dependencies {
 
     // CorDapp dependencies.
     cordapp project(":cordapp-contracts-states")
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
-    kotlinOptions {
-        languageVersion = "1.2"
-        apiVersion = "1.2"
-        jvmTarget = "1.8"
-        javaParameters = true   // Useful for reflection.
-    }
 }

--- a/contract-upgrades/cordapp-new-contract/build.gradle
+++ b/contract-upgrades/cordapp-new-contract/build.gradle
@@ -28,9 +28,6 @@ dependencies {
 
     // Corda dependencies.
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-jackson:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-rpc:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-node-api:$corda_release_version"
 
     // CorDapp dependencies.
     cordapp project(":cordapp-contracts-states")

--- a/contract-upgrades/cordapp/build.gradle
+++ b/contract-upgrades/cordapp/build.gradle
@@ -1,12 +1,3 @@
-repositories {
-    mavenLocal()
-    jcenter()
-    mavenCentral()
-    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
-    maven { url 'https://jitpack.io' }
-}
-
-apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.cordapp'
 apply plugin: 'net.corda.plugins.quasar-utils'
 
@@ -36,13 +27,4 @@ dependencies {
     // CorDapp dependencies.
     cordapp project(":cordapp-contracts-states")
     cordapp project(":cordapp-new-contract")
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
-    kotlinOptions {
-        languageVersion = "1.2"
-        apiVersion = "1.2"
-        jvmTarget = "1.8"
-        javaParameters = true   // Useful for reflection.
-    }
 }

--- a/contract-upgrades/src/main/kotlin/com/upgrade/client/ClientWithLegacyConstraint.kt
+++ b/contract-upgrades/src/main/kotlin/com/upgrade/client/ClientWithLegacyConstraint.kt
@@ -43,7 +43,7 @@ private class UpgradeContractClientWithLegacyConstraint {
         listOf(partyBProxy).forEach { proxy ->
             // Extract all the unconsumed State instances from the vault.
             val stateAndRefs = proxy.vaultQuery(OldState::class.java).states
-            println("authorise = ${stateAndRefs}")
+            println("authorise = $stateAndRefs")
 
             // Run the upgrading flow for each one.
             stateAndRefs
@@ -63,7 +63,7 @@ private class UpgradeContractClientWithLegacyConstraint {
                     stateAndRef.state.contract == OldContract.id
                 }
                 .forEach { stateAndRef ->
-                    println("upgrade: " + stateAndRef)
+                    println("upgrade: $stateAndRef")
                     partyAProxy.startFlowDynamic(
                             ContractUpgradeFlow.Initiate::class.java,
                             stateAndRef,

--- a/corda-nodeinfo/build.gradle
+++ b/corda-nodeinfo/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'

--- a/cordapp-example/build.gradle
+++ b/cordapp-example/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'

--- a/cordapp-example/contracts-java/build.gradle
+++ b/cordapp-example/contracts-java/build.gradle
@@ -17,8 +17,6 @@ cordapp {
 dependencies {
     // Corda dependencies.
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-jackson:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-rpc:$corda_release_version"
 }
 
 tasks.withType(JavaCompile) {

--- a/cordapp-example/contracts-kotlin/build.gradle
+++ b/cordapp-example/contracts-kotlin/build.gradle
@@ -21,8 +21,6 @@ dependencies {
 
     // Corda dependencies.
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-jackson:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-rpc:$corda_release_version"
 }
 
 tasks.withType(KotlinCompile) {

--- a/cordapp-example/workflows-java/build.gradle
+++ b/cordapp-example/workflows-java/build.gradle
@@ -79,6 +79,10 @@ task deployNodes(type: Cordform, dependsOn: ['jar']) {
             address("localhost:10001")
             adminAddress("localhost:10002")
         }
+        projectCordapp {
+            deploy = false
+        }
+        cordapps.clear()
     }
     node {
         name "O=PartyA,L=London,C=GB"

--- a/cordapp-example/workflows-kotlin/build.gradle
+++ b/cordapp-example/workflows-kotlin/build.gradle
@@ -87,6 +87,10 @@ task deployNodes(type: Cordform, dependsOn: ['jar']) {
             address("localhost:10001")
             adminAddress("localhost:10002")
         }
+        projectCordapp {
+            deploy = false
+        }
+        cordapps.clear()
     }
     node {
         name "O=PartyA,L=London,C=GB"

--- a/flow-db/build.gradle
+++ b/flow-db/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'

--- a/flow-http/build.gradle
+++ b/flow-http/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'

--- a/heartbeat/build.gradle
+++ b/heartbeat/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'

--- a/negotiation-cordapp/build.gradle
+++ b/negotiation-cordapp/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'
@@ -55,7 +55,7 @@ dependencies {
     cordaRuntime "$corda_release_group:corda:$corda_release_version"
 
     // Silences a warning from the deployNodes task.
-    testRuntimeOnly "org.slf4j:slf4j-nop:$slf4j_version"
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {

--- a/negotiation-cordapp/contracts/build.gradle
+++ b/negotiation-cordapp/contracts/build.gradle
@@ -25,9 +25,6 @@ dependencies {
 
     // Corda dependencies.
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-jackson:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-rpc:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-node-api:$corda_release_version"
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/obligation-cordapp/build.gradle
+++ b/obligation-cordapp/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'

--- a/obligation-cordapp/java-source/build.gradle
+++ b/obligation-cordapp/java-source/build.gradle
@@ -83,6 +83,10 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address("localhost:10003")
             adminAddress("localhost:10043")
         }
+        projectCordapp {
+            deploy = false
+        }
+        cordapps.clear()
     }
     node {
         name "O=PartyA,L=London,C=GB"

--- a/obligation-cordapp/kotlin-source/build.gradle
+++ b/obligation-cordapp/kotlin-source/build.gradle
@@ -90,6 +90,10 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address("localhost:10003")
             adminAddress("localhost:10043")
         }
+        projectCordapp {
+            deploy = false
+        }
+        cordapps.clear()
     }
     node {
         name "O=PartyA,L=London,C=GB"

--- a/observable-states/build.gradle
+++ b/observable-states/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'
@@ -59,7 +59,7 @@ dependencies {
     testRuntimeOnly "$corda_release_group:corda-node-api:$corda_release_version"
 
     // Silences a warning from the deployNodes task.
-    testRuntimeOnly "org.slf4j:slf4j-nop:$slf4j_version"
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
@@ -79,6 +79,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address("localhost:10003")
             adminAddress("localhost:10004")
         }
+        cordapps.clear()
     }
     node {
         name "O=Seller,L=London,C=GB"

--- a/oracle-example/.idea/runConfigurations/PrimesClientTests.xml
+++ b/oracle-example/.idea/runConfigurations/PrimesClientTests.xml
@@ -1,28 +1,23 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="PrimesClientTests" type="JUnit" factoryName="JUnit" nameIsGenerated="true">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+    <module name="net.corda.examples.oracle.oracle-example.test" />
+    <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="net.corda.examples.oracle.client.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>
-    <module name="oracle-example_test" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="ALTERNATIVE_JRE_PATH" value="1.8" />
     <option name="PACKAGE_NAME" value="net.corda.examples.oracle.client" />
     <option name="MAIN_CLASS_NAME" value="net.corda.examples.oracle.client.PrimesClientTests" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
     <option name="VM_PARAMETERS" value="-ea -javaagent:lib/quasar.jar" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/oracle-example/.idea/runConfigurations/PrimesServiceTests.xml
+++ b/oracle-example/.idea/runConfigurations/PrimesServiceTests.xml
@@ -1,28 +1,23 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="PrimesServiceTests" type="JUnit" factoryName="JUnit" nameIsGenerated="true">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+    <module name="net.corda.examples.oracle.oracle-example.test" />
+    <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="net.corda.examples.oracle.service.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>
-    <module name="oracle-example_test" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="ALTERNATIVE_JRE_PATH" value="1.8" />
     <option name="PACKAGE_NAME" value="net.corda.examples.oracle.service" />
     <option name="MAIN_CLASS_NAME" value="net.corda.examples.oracle.service.PrimesServiceTests" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
-    <option name="VM_PARAMETERS" value="-ea" />
+    <option name="VM_PARAMETERS" value="-ea -javaagent:lib/quasar.jar" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/oracle-example/.idea/runConfigurations/Run_Oracle_CorDapp.xml
+++ b/oracle-example/.idea/runConfigurations/Run_Oracle_CorDapp.xml
@@ -1,15 +1,15 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Oracle CorDapp" type="JetRunConfigurationType" factoryName="Kotlin">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
-    <option name="MAIN_CLASS_NAME" value="net.corda.examples.oracle.MainKt" />
-    <option name="VM_PARAMETERS" value="" />
+    <module name="net.corda.examples.oracle.oracle-example.test" />
+    <option name="VM_PARAMETERS" value="-javaagent:lib/quasar.jar" />
     <option name="PROGRAM_PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="ALTERNATIVE_JRE_PATH" value="1.8" />
     <option name="PASS_PARENT_ENVS" value="true" />
-    <module name="oracle-example_test" />
-    <envs />
-    <method />
+    <option name="MAIN_CLASS_NAME" value="net.corda.examples.oracle.MainKt" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/oracle-example/build.gradle
+++ b/oracle-example/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'
@@ -35,7 +35,6 @@ repositories {
 apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.cordapp'
 apply plugin: 'net.corda.plugins.cordformation'
-apply plugin: 'net.corda.plugins.quasar-utils'
 
 cordapp {
     targetPlatformVersion corda_platform_version.toInteger()

--- a/pigtail/build.gradle
+++ b/pigtail/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'

--- a/reference-states/build.gradle
+++ b/reference-states/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'
+        slf4j_version = '1.7.25'
         quasar_version = '0.7.10'
         corda_platform_version = '4'
     }
@@ -35,4 +36,87 @@ allprojects {
         maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
         maven { url 'https://jitpack.io' }
     }
+}
+
+apply plugin: 'kotlin'
+apply plugin: 'net.corda.plugins.cordapp'
+apply plugin: 'net.corda.plugins.cordformation'
+
+cordapp {
+    info {
+        name "CorDapp Reference Flows Example"
+        vendor "Corda Open Source"
+        targetPlatformVersion corda_platform_version.toInteger()
+        minimumPlatformVersion corda_platform_version.toInteger()
+    }
+}
+
+dependencies {
+    cordaRuntime "$corda_release_group:corda:$corda_release_version"
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+
+    // CorDapp dependencies.
+    cordapp project(":reference-example-contracts")
+    cordapp project(":reference-example-flows")
+}
+
+task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
+
+    nodeDefaults {
+        projectCordapp {
+            deploy = false
+        }
+        cordapp project(":reference-example-contracts")
+        cordapp project(":reference-example-flows")
+        rpcUsers = [['username': "default", 'password': "default", 'permissions': [ 'ALL' ]]]
+    }
+
+    node {
+        name "O=Notary,L=London,C=GB"
+        notary = [validating: false]
+        p2pPort 10000
+        rpcSettings {
+            address("localhost:10001")
+            adminAddress("localhost:10002")
+        }
+        cordapps.clear()
+    }
+    node {
+        name "O=SanctionsBody,L=London,C=GB"
+        p2pPort 10004
+        rpcSettings {
+            address("localhost:10005")
+            adminAddress("localhost:10006")
+        }
+    }
+    node {
+        name "O=IOUPartyA,L=New York,C=US"
+        p2pPort 10008
+        rpcSettings {
+            address("localhost:10009")
+            adminAddress("localhost:10010")
+        }
+    }
+    node {
+        name "O=IOUPartyB,L=Paris,C=FR"
+        p2pPort 10012
+        rpcSettings {
+            address("localhost:10013")
+            adminAddress("localhost:10014")
+        }
+    }
+    node {
+        name "O=DodgyParty,L=Moscow,C=RU"
+        p2pPort 10016
+        rpcSettings {
+            address("localhost:10017")
+            adminAddress("localhost:10018")
+        }
+    }
+}
+
+task runExampleClientRPCKotlin(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'com.example.client.ExampleClientRPCKt'
+    args 'localhost:10005'
 }

--- a/reference-states/reference-example-contracts/build.gradle
+++ b/reference-states/reference-example-contracts/build.gradle
@@ -2,11 +2,13 @@ apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.cordapp'
 
 cordapp {
-    info {
+    targetPlatformVersion corda_platform_version.toInteger()
+    minimumPlatformVersion corda_platform_version.toInteger()
+    contract {
         name "CorDapp Reference Contracts Example"
         vendor "Corda Open Source"
-        targetPlatformVersion corda_platform_version.toInteger()
-        minimumPlatformVersion corda_platform_version.toInteger()
+        licence "Apache License, Version 2.0"
+        versionId 1
     }
 }
 
@@ -25,8 +27,6 @@ dependencies {
 
     // Corda dependencies.
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-jackson:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-rpc:$corda_release_version"
 
     testCompile "$corda_release_group:corda-node-driver:$corda_release_version"
 }

--- a/reference-states/reference-example-flows/build.gradle
+++ b/reference-states/reference-example-flows/build.gradle
@@ -1,23 +1,19 @@
 apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.cordapp'
-apply plugin: 'net.corda.plugins.cordformation'
 apply plugin: 'net.corda.plugins.quasar-utils'
 
 cordapp {
-    info {
+    targetPlatformVersion corda_platform_version.toInteger()
+    minimumPlatformVersion corda_platform_version.toInteger()
+    workflow {
         name "CorDapp Reference Flows Example"
         vendor "Corda Open Source"
-        targetPlatformVersion corda_platform_version.toInteger()
-        minimumPlatformVersion corda_platform_version.toInteger()
+        licence "Apache License, Version 2.0"
+        versionId 1
     }
 }
 
 sourceSets {
-    main {
-        resources {
-            srcDir "../config/dev"
-        }
-    }
     test {
         resources {
             srcDir "../config/test"
@@ -46,7 +42,6 @@ dependencies {
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
     cordaCompile "$corda_release_group:corda-jackson:$corda_release_version"
     cordaCompile "$corda_release_group:corda-rpc:$corda_release_version"
-    cordaRuntime "$corda_release_group:corda:$corda_release_version"
 
     testCompile "$corda_release_group:corda-node-driver:$corda_release_version"
     // CorDapp dependencies.
@@ -65,61 +60,4 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
         jvmTarget = "1.8"
         javaParameters = true   // Useful for reflection.
     }
-}
-
-task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
-
-    nodeDefaults {
-        cordapp project(":reference-example-contracts")
-        rpcUsers = [['username': "default", 'password': "default", 'permissions': [ 'ALL' ]]]
-    }
-
-
-    node {
-        name "O=Notary,L=London,C=GB"
-        notary = [validating: false]
-        p2pPort 10000
-        rpcSettings {
-            address("localhost:10001")
-            adminAddress("localhost:10002")
-        }
-    }
-    node {
-        name "O=SanctionsBody,L=London,C=GB"
-        p2pPort 10004
-        rpcSettings {
-            address("localhost:10005")
-            adminAddress("localhost:10006")
-        }
-    }
-    node {
-        name "O=IOUPartyA,L=New York,C=US"
-        p2pPort 10008
-        rpcSettings {
-            address("localhost:10009")
-            adminAddress("localhost:10010")
-        }
-    }
-    node {
-        name "O=IOUPartyB,L=Paris,C=FR"
-        p2pPort 10012
-        rpcSettings {
-            address("localhost:10013")
-            adminAddress("localhost:10014")
-        }
-    }
-    node {
-        name "O=DodgyParty,L=Moscow,C=RU"
-        p2pPort 10016
-        rpcSettings {
-            address("localhost:10017")
-            adminAddress("localhost:10018")
-        }
-    }
-}
-
-task runExampleClientRPCKotlin(type: JavaExec) {
-    classpath = sourceSets.main.runtimeClasspath
-    main = 'com.example.client.ExampleClientRPCKt'
-    args 'localhost:10005'
 }

--- a/spring-webserver/build.gradle
+++ b/spring-webserver/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'

--- a/whistleblower/README.md
+++ b/whistleblower/README.md
@@ -27,9 +27,11 @@ We will interact with this CorDapp via the nodes' CRaSH shells.
   
 First, go the the shell of BraveEmployee, and report BadCompany to the TradeBody by running:
 
-    ???
+    flow start BlowWhistleFlow badCompany: BadCompany, investigator: TradeBody
     
 To see the whistle-blowing case stored on the whistle-blowing node, run:
+
+    run vaultQuery contractStateType: com.whistleblower.BlowWhistleState
 
     [ {
       "badCompany" : "C=KE,L=Eldoret,O=BadCompany",

--- a/whistleblower/build.gradle
+++ b/whistleblower/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'

--- a/yo-cordapp/build.gradle
+++ b/yo-cordapp/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_release_group = 'net.corda'
-        corda_release_version = '4.0-RC06'
+        corda_release_version = '4.0-RC07'
         corda_gradle_plugins_version = '4.0.40'
         kotlin_version = '1.2.71'
         junit_version = '4.12'
@@ -101,7 +101,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address("localhost:10003")
             adminAddress("localhost:10043")
         }
-        cordapps = []
     }
     node {
         name "O=PartyA,L=London,C=GB"
@@ -110,7 +109,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address("localhost:10006")
             adminAddress("localhost:10046")
         }
-        cordapps = []
         rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
     }
     node {
@@ -120,19 +118,6 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
             address("localhost:10009")
             adminAddress("localhost:10049")
         }
-        cordapps = []
         rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
     }
-}
-
-task runYoRPCNodeA(type: JavaExec) {
-    classpath = sourceSets.main.runtimeClasspath
-    main = 'net.corda.yo.ClientKt'
-    args 'localhost:10006'
-}
-
-task runYoRPCNodeB(type: JavaExec) {
-    classpath = sourceSets.main.runtimeClasspath
-    main = 'net.corda.yo.ClientKt'
-    args 'localhost:10009'
 }


### PR DESCRIPTION
- Update to 4.0-RC07.
- Don't mix `cordformation` and `cordapp` plugins unnecessarily.
- Remove CorDapps from non-validating Notary nodes.
- Fill in blanks for Whistleblower documentation.
- Refactor Gradle files for Contract Upgrade to remove repetition.