### PR TITLE
[CORDA-2831] Update the Obligation CorDapp after review of the Update CorDapp

### DIFF
--- a/obligation-cordapp/TRADEMARK
+++ b/obligation-cordapp/TRADEMARK
@@ -1,4 +1,4 @@
-Corda and the Corda logo are trademarks of R3CEV LLC and its affiliates.
+Corda and the Corda logo are trademarks of R3 HoldCo LLC and its affiliates.
 All rights reserved.
 
-For R3CEV LLC's trademark and logo usage information, please consult our Trademark Usage Policy available at https://www.r3.com/trademark-usage-policy
+For R3 HoldCo LLC's trademark and logo usage information, please consult our Trademark Usage Policy available at https://www.r3.com/trademark-policy

--- a/obligation-cordapp/kotlin-source/src/main/kotlin/net/corda/examples/obligation/Obligation.kt
+++ b/obligation-cordapp/kotlin-source/src/main/kotlin/net/corda/examples/obligation/Obligation.kt
@@ -19,6 +19,13 @@ data class Obligation(val amount: Amount<Currency>,
 
     override val participants: List<AbstractParty> get() = listOf(lender, borrower)
 
+    init {
+        check(amount.token == paid.token) {
+            "Obligation requires the same currency for the amount owed and the amount paid, but is using ${amount.token}" +
+            " for the amount owed and ${paid.token} for the amount paid."
+        }
+    }
+
     fun pay(amountToPay: Amount<Currency>) = copy(paid = paid + amountToPay)
     fun withNewLender(newLender: AbstractParty) = copy(lender = newLender)
     fun withoutLender() = copy(lender = NullKeys.NULL_PARTY)

--- a/obligation-cordapp/kotlin-source/src/main/kotlin/net/corda/examples/obligation/ObligationContract.kt
+++ b/obligation-cordapp/kotlin-source/src/main/kotlin/net/corda/examples/obligation/ObligationContract.kt
@@ -9,8 +9,7 @@ import java.security.PublicKey
 class ObligationContract : Contract {
 
     companion object {
-        @JvmStatic
-        val OBLIGATION_CONTRACT_ID = "net.corda.examples.obligation.ObligationContract"
+        const val OBLIGATION_CONTRACT_ID = "net.corda.examples.obligation.ObligationContract"
     }
 
     interface Commands : CommandData {
@@ -57,6 +56,7 @@ class ObligationContract : Contract {
         "The lender property must change in a transfer." using (input.lender != output.lender)
         "The borrower, old lender and new lender only must sign an obligation transfer transaction" using
                 (signers == (keysFromParticipants(input) union keysFromParticipants(output)))
+        "The new lender must not be the borrower" using (output.lender != output.borrower)
     }
 
     private fun verifySettle(tx: LedgerTransaction, signers: Set<PublicKey>) = requireThat {

--- a/obligation-cordapp/kotlin-source/src/main/kotlin/net/corda/examples/obligation/flows/ObligationBaseFlow.kt
+++ b/obligation-cordapp/kotlin-source/src/main/kotlin/net/corda/examples/obligation/flows/ObligationBaseFlow.kt
@@ -44,3 +44,12 @@ internal class SignTxFlowNoChecking(otherFlow: FlowSession) : SignTransactionFlo
         // TODO: Add checking here.
     }
 }
+
+/**
+ * A version of check that throws a FlowException rather than an IllegalArgumentException
+ */
+inline fun flowCheck(value: Boolean, msg: () -> String) {
+    if (!value) {
+        throw FlowException(msg())
+    }
+}

--- a/obligation-cordapp/kotlin-source/src/main/kotlin/net/corda/examples/obligation/flows/SettleObligation.kt
+++ b/obligation-cordapp/kotlin-source/src/main/kotlin/net/corda/examples/obligation/flows/SettleObligation.kt
@@ -51,21 +51,21 @@ object SettleObligation {
             val lenderIdentity = resolveIdentity(inputObligation.lender)
 
             // Stage 3. This flow can only be initiated by the current recipient.
-            check(borrowerIdentity == ourIdentity) {
-                throw FlowException("Settle Obligation flow must be initiated by the borrower.")
+            flowCheck(borrowerIdentity == ourIdentity) {
+                "Settle Obligation flow must be initiated by the borrower."
             }
 
             // Stage 4. Check we have enough cash to settle the requested amount.
             val cashBalance = serviceHub.getCashBalance(amount.token)
             val amountLeftToSettle = inputObligation.amount - inputObligation.paid
-            check(cashBalance.quantity > 0L) {
-                throw FlowException("Borrower has no ${amount.token} to settle.")
+            flowCheck(cashBalance.quantity > 0L) {
+                "Borrower has no ${amount.token} to settle."
             }
-            check(cashBalance >= amount) {
-                throw FlowException("Borrower has only $cashBalance but needs $amount to settle.")
+            flowCheck(cashBalance >= amount) {
+                "Borrower has only $cashBalance but needs $amount to settle."
             }
-            check(amountLeftToSettle >= amount) {
-                throw FlowException("There's only $amountLeftToSettle left to settle but you pledged $amount.")
+            flowCheck(amountLeftToSettle >= amount) {
+                "There's only $amountLeftToSettle left to settle but you pledged $amount."
             }
 
             // Stage 5. Create a settle command.

--- a/obligation-cordapp/kotlin-source/src/main/kotlin/net/corda/examples/obligation/flows/TransferObligation.kt
+++ b/obligation-cordapp/kotlin-source/src/main/kotlin/net/corda/examples/obligation/flows/TransferObligation.kt
@@ -62,7 +62,7 @@ object TransferObligation {
 
             // Stage 2. This flow can only be initiated by the current lender. Abort if the borrower started this flow.
             progressTracker.currentStep = CHECK_INITIATOR
-            check(ourIdentity == getLenderIdentity(inputObligation)) { "Obligation transfer can only be initiated by the lender." }
+            flowCheck(ourIdentity == getLenderIdentity(inputObligation)) { "Obligation transfer can only be initiated by the lender." }
 
             // Stage 3. Create the new obligation state reflecting a new lender.
             // This step has to interact with the new lender to exchange identities if we are using anonymous identities.

--- a/obligation-cordapp/kotlin-source/src/test/kotlin/net/corda/examples/obligation/flows/TransferObligationTests.kt
+++ b/obligation-cordapp/kotlin-source/src/test/kotlin/net/corda/examples/obligation/flows/TransferObligationTests.kt
@@ -1,5 +1,6 @@
 package net.corda.examples.obligation.flows
 
+import net.corda.core.flows.FlowException
 import net.corda.examples.obligation.Obligation
 import net.corda.finance.POUNDS
 import net.corda.testing.internal.chooseIdentity
@@ -62,7 +63,7 @@ class TransferObligationTests : ObligationTests() {
         val issuedObligation = issuanceTransaction.tx.outputStates.first() as Obligation
 
         // Transfer obligation.
-        kotlin.test.assertFailsWith<IllegalStateException> {
+        kotlin.test.assertFailsWith<FlowException> {
             transferObligation(issuedObligation.linearId, a, c, anonymous = false)
         }
     }


### PR DESCRIPTION
The new Update CorDapp is heavily based on the Obligation CorDapp. A review of the former found a number of underlying issues in the latter, which are fixed in this PR.

Changes:
 - Update TRADEMARK
 - Check that `Currency`s are the same for the amount owed and the amount paid
 - Add a check to the contract that prevents the lender and borrower being the same party on transfer
 - Correct the use of `check`.