### PR TITLE
Fix cordapp examples: Provide Node Driver with a list of Cordapps to load

### DIFF
--- a/cordapp-example/workflows-java/src/test/java/com/example/test/NodeDriver.java
+++ b/cordapp-example/workflows-java/src/test/java/com/example/test/NodeDriver.java
@@ -7,8 +7,10 @@ import net.corda.core.identity.CordaX500Name;
 import net.corda.testing.driver.DriverParameters;
 import net.corda.testing.driver.NodeHandle;
 import net.corda.testing.driver.NodeParameters;
+import net.corda.testing.node.TestCordapp;
 import net.corda.testing.node.User;
 
+import java.util.Collections;
 import java.util.List;
 
 import static net.corda.testing.driver.Driver.driver;
@@ -20,7 +22,7 @@ import static net.corda.testing.driver.Driver.driver;
 public class NodeDriver {
     public static void main(String[] args) {
         final User user = new User("user1", "test", ImmutableSet.of("ALL"));
-        driver(new DriverParameters().withWaitForAllNodesToFinish(true), dsl -> {
+        driver(new DriverParameters().withWaitForAllNodesToFinish(true).withCordappsForAllNodes(Collections.singletonList(TestCordapp.findCordapp("com.example.flow"))), dsl -> {
                     List<CordaFuture<NodeHandle>> nodeFutures = ImmutableList.of(
                             dsl.startNode(new NodeParameters()
                                     .withProvidedName(new CordaX500Name("PartyA", "London", "GB"))

--- a/cordapp-example/workflows-kotlin/src/test/kotlin/com/example/test/NodeDriver.kt
+++ b/cordapp-example/workflows-kotlin/src/test/kotlin/com/example/test/NodeDriver.kt
@@ -4,6 +4,7 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
+import net.corda.testing.node.TestCordapp
 import net.corda.testing.node.User
 
 /**
@@ -12,7 +13,7 @@ import net.corda.testing.node.User
  */
 fun main(args: Array<String>) {
     val user = User("user1", "test", permissions = setOf("ALL"))
-    driver(DriverParameters(waitForAllNodesToFinish = true)) {
+    driver(DriverParameters(waitForAllNodesToFinish = true, cordappsForAllNodes = listOf(TestCordapp.findCordapp("com.example.flow")))) {
         val nodeFutures = listOf(
                 startNode(
                         providedName = CordaX500Name("PartyA", "London", "GB"),


### PR DESCRIPTION
Seems like the driver now requires the list of cordapps to load.

Updated both Java and Kotlin versions of the example.