### PR TITLE
[CORDA-3082] Fix a build issue relating to a type inference limitation

### DIFF
--- a/implicit-cordapp-upgrades/workflows/v3-can-default/src/main/kotlin/net/corda/examples/obligation/workflow/flows/IssueObligation.kt
+++ b/implicit-cordapp-upgrades/workflows/v3-can-default/src/main/kotlin/net/corda/examples/obligation/workflow/flows/IssueObligation.kt
@@ -4,6 +4,7 @@ import co.paralleluniverse.fibers.Suspendable
 import net.corda.confidential.SwapIdentitiesFlow
 import net.corda.core.contracts.Amount
 import net.corda.core.flows.*
+import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
@@ -87,7 +88,7 @@ object IssueObligation {
                 val anonymousIdentitiesResult = subFlow(SwapIdentitiesFlow(lenderSession))
                 Pair(anonymousIdentitiesResult[lenderSession.counterparty]!!, anonymousIdentitiesResult[ourIdentity]!!)
             } else {
-                Pair(lender, ourIdentity)
+                Pair<AbstractParty, AbstractParty>(lender, ourIdentity)
             }
 
             // V3: When creating a new obligation, fill in the new field.


### PR DESCRIPTION
A change introduced by https://r3-cev.atlassian.net/browse/CID-878 has exposed a type inference limitation in the compiler that is unfortunately hit by one of our samples. CID-878 introduces a `Destination` interface that is implemented by both `AnonymousParty` and `Party`. Both of these subclass `AbstractParty`. The sample in question uses a variable that is conditionally one of `AnonymousParty` or `Party`, depending on whether a flag is set. This variable is only used as an `AbstractParty`. Without the extra `Destination` interface, the compiler can infer this with no further annotation, however the addition of this interface confuses the compiler and causes it to treat the variable as `Any` - which then breaks when an attempt is made to use it as an `AbstractParty`.

This fix adds just enough type annotations to convince the compiler that the variable is in fact an `AbstractParty`.