### PR TITLE
[NOTICK] Update jar hash in explicit upgrade sample

### DIFF
--- a/explicit-cordapp-upgrades/cordapp-new-contract-with-legacy-constraint/src/main/kotlin/com/upgrade/legacy/constraint/new/NewContractWithLegacyConstraint.kt
+++ b/explicit-cordapp-upgrades/cordapp-new-contract-with-legacy-constraint/src/main/kotlin/com/upgrade/legacy/constraint/new/NewContractWithLegacyConstraint.kt
@@ -11,7 +11,7 @@ import net.corda.core.transactions.LedgerTransaction
 class NewContractWithLegacyConstraint : UpgradedContractWithLegacyConstraint<OldState, NewState> {
 
     // SHA-256 hash of the JAR containing the old contract.
-    override val legacyContractConstraint = HashAttachmentConstraint(SecureHash.parse("6D8435DF0A4654F1498B0BCF99C3CDE2C8EC2929CEA8E9455F4B992274561776"))
+    override val legacyContractConstraint = HashAttachmentConstraint(SecureHash.parse("1B31DB2D8D6A57D49B530FE9D3C7856728A62F94E1BDCD294FBDA90DE62B3108"))
 
     companion object {
         const val id = "com.upgrade.new.with.legacy.constraint.NewContractWithLegacyConstraint"


### PR DESCRIPTION
Updating the platform version of the samples changed the JAR hash of the unupgraded CorDapp in the `explicit-cordapp-upgrades` sample. This PR updates the corresponding hash in `NewContractWithLegacyConstraint` to keep the unit tests passing.