### PR TITLE
[NOTICK] Update jar hash in explicit upgrade sample

### DIFF
--- a/explicit-cordapp-upgrades/cordapp-new-contract-with-legacy-constraint/src/main/kotlin/com/upgrade/legacy/constraint/new/NewContractWithLegacyConstraint.kt
+++ b/explicit-cordapp-upgrades/cordapp-new-contract-with-legacy-constraint/src/main/kotlin/com/upgrade/legacy/constraint/new/NewContractWithLegacyConstraint.kt
@@ -11,7 +11,7 @@ import net.corda.core.transactions.LedgerTransaction
 class NewContractWithLegacyConstraint : UpgradedContractWithLegacyConstraint<OldState, NewState> {
 
     // SHA-256 hash of the JAR containing the old contract.
-    override val legacyContractConstraint = HashAttachmentConstraint(SecureHash.parse("1B31DB2D8D6A57D49B530FE9D3C7856728A62F94E1BDCD294FBDA90DE62B3108"))
+    override val legacyContractConstraint = HashAttachmentConstraint(SecureHash.parse("ABAE2671E815FC545DC53586CCFAB2D2543E903E70F70F496F71035C65EFF794"))
 
     companion object {
         const val id = "com.upgrade.new.with.legacy.constraint.NewContractWithLegacyConstraint"


### PR DESCRIPTION
The Contract Upgrade sample uses an incorrect hash for the legacy constraint version after the platform version was increased. This PR updates it again, after realising that the hash is operating system dependent. Note that this means the test will not pass on Windows, but that has always been the case historically.