### PR TITLE
Correct order of SIGNING and VERIFYING in Flow.kt

### DIFF
--- a/yo-cordapp/workflows/src/main/kotlin/net/corda/examples/yo/flows/Flows.kt
+++ b/yo-cordapp/workflows/src/main/kotlin/net/corda/examples/yo/flows/Flows.kt
@@ -42,11 +42,11 @@ class YoFlow(val target: Party) : FlowLogic<SignedTransaction>() {
         val stateAndContract = StateAndContract(state, YoContract.ID)
         val utx = TransactionBuilder(notary = notary).withItems(stateAndContract, command)
 
+        progressTracker.currentStep = VERIFYING
+        utx.verify(serviceHub)
+
         progressTracker.currentStep = SIGNING
         val stx = serviceHub.signInitialTransaction(utx)
-
-        progressTracker.currentStep = VERIFYING
-        stx.verify(serviceHub)
 
         progressTracker.currentStep = FINALISING
         val targetSession = initiateFlow(target)


### PR DESCRIPTION
Since it is a Flow that issues a State, the order of “SIGNING → VERIFYING” is fine, but when trying to expand to a Flow with InputState, an error will occur unless it is “VERIFYING → SIGNING”.

Developers who want to extend and implement this Sample Repository are easy to make mistakes, so we should fix them.